### PR TITLE
search posts from a user

### DIFF
--- a/app/controllers/api/v1/posts_searches_controller.rb
+++ b/app/controllers/api/v1/posts_searches_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::PostsSearchesController < SearchController
   def search
     return if too_many_keywords?
 
-    posts = Post.find_posts(keywords, post_status, turn_pages, max_content)
+    posts = Post.find_posts(keywords, post_status, author, turn_pages, max_content)
 
     results = generate_results(posts, keywords)
     hit_count = Post.count_hit(keywords, post_status)
@@ -18,8 +18,10 @@ class Api::V1::PostsSearchesController < SearchController
   private
 
   # レスポンスに入れる投稿のダイジェストの配列を生成する
-  def generate_results(grouped_posts_array, keywords)
-    grouped_posts_array.map do |post|
+  def generate_results(posts, keywords)
+    # N + 1問題対策
+    ActiveRecord::Associations::Preloader.new.preload(posts, [:user])
+    posts.map do |post|
       body_result = take_string(post.body, keywords.first)
       code_result = take_string(post.code, keywords.first)
       {
@@ -28,7 +30,10 @@ class Api::V1::PostsSearchesController < SearchController
         body: body_result,
         code: code_result,
         status: post.state,
-        reward: post.bestanswer_reward
+        reward: post.bestanswer_reward,
+        author: {
+          name: post.user.name
+        }
       }
     end
   end
@@ -38,5 +43,11 @@ class Api::V1::PostsSearchesController < SearchController
     return '%_%' unless POST_STATUS.any?(params[:status])
 
     params.permit(:status)[:status]
+  end
+
+  def author
+    return '' unless params[:author]&.is_a?(String)
+
+    params.permit(:author)[:author]
   end
 end

--- a/app/controllers/api/v1/posts_searches_controller.rb
+++ b/app/controllers/api/v1/posts_searches_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::PostsSearchesController < SearchController
     posts = Post.find_posts(keywords, post_status, author, turn_pages, max_content)
 
     results = generate_results(posts, keywords)
-    hit_count = Post.count_hit(keywords, post_status)
+    hit_count = Post.count_hit(keywords, post_status, author)
 
     render_results(results, hit_count)
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,7 +46,7 @@ class Post < ApplicationRecord
     end
   end
 
-  def self.count_hit(keywords, post_state, author)
+  def self.count_search_results(keywords, post_state, author)
     Post.count_by_sql(Post.arel_table
                         .project('count(*)')
                         .from(join_keywords_results(keywords).as('result'))

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,13 +46,14 @@ class Post < ApplicationRecord
     end
   end
 
-  def self.count_hit(keywords, post_state)
-    Post.find_by_sql(Post.arel_table
-                       .project('result.id')
-                       .from(join_keywords_results(keywords).as('result'))
-                       .where(set_post_state(post_state))
-                       .distinct('result.id')
-                       .to_sql).count
+  def self.count_hit(keywords, post_state, author)
+    Post.count_by_sql(Post.arel_table
+                        .project('count(*)')
+                        .from(join_keywords_results(keywords).as('result'))
+                        .where(set_post_state(post_state)
+                                 .and(set_author(author)))
+                        .distinct('result.id')
+                        .to_sql)
   end
 
   def self.find_posts(keywords, post_state, author, page, max_content)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -102,7 +102,7 @@ class Post < ApplicationRecord
       return (Arel::Table.new :result)[:user_id].matches('%_%')
     end
 
-    (Arel::Table.new :result)[:user_id].matches(user ? user.id : nil)
+    (Arel::Table.new :result)[:user_id].eq(user ? user.id : nil)
   end
 
   def set_default_reward

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
                        .to_sql)
   end
 
-  def self.count_hit(keywords)
+  def self.count_search_results(keywords)
     Post.find_by_sql(Post.arel_table
                        .project('result.id')
                        .from(keywords_results_from_users(keywords).as('result'))

--- a/test/controllers/posts_searches_controller_test.rb
+++ b/test/controllers/posts_searches_controller_test.rb
@@ -49,4 +49,15 @@ class PostsSearchesControllerTest < ActionDispatch::IntegrationTest
 
     assert body['body']['results'].empty?
   end
+
+  test 'posts count should be 10' do
+    10.times do
+      @user.posts.create(title: 'hoge', body: 'hoge', code: 'hoge', source_url: 'test')
+    end
+
+    get '/api/v1/search/posts', params: { keyword: 'hoge', author: @user.name }
+    body = JSON.parse(response.body)
+
+    assert body['body']['hit_total'] == 10
+  end
 end


### PR DESCRIPTION
検索の総ヒット件数の処理を軽くして、更に投稿をユーザー名で絞り込んで検索できるようにして、投稿の検索結果のプロパティにauthor(書いた人)を追加しました。  
ユーザーページに飛んだ時に、下の方にその人の投稿一覧とかを表示したい場合、検索APIにauthorを指定してリクエストを投げるといいかもしれません。  
そうすると、その人の投稿だけを絞り込んで表示ができます。  
リクエストの形の例
```
get /api/v1/search/posts

{
    "keyword": "test",
    "page_number": 1,
    "max_content": 10,
    "author": "takashiii"
}
```  
レスポンスの結果（配列）の要素の例
```
{
        "id": 120073,
        "title": "test99993",
        "body": "test99993",
        "code": "code99993",
        "status": "accepting",
        "reward": 100,
        "author": {
           "name": "takashiii"
       }
}
```