### PR TITLE
reviews and responses

### DIFF
--- a/api-documents/api/v1/responses/api.md
+++ b/api-documents/api/v1/responses/api.md
@@ -1,0 +1,19 @@
+#### post /api/v1/posts/id/reviews/review_id
+
+idは何でもよく(現状死にパラメーター)、review_idは必ずレビューのIDである必要があります。  
+存在しないID、もしくはresponseであってはいけません。  
+
+必要なparameterの例
+
+```json
+{
+   "token": {
+             "onetime": "your onetime token here"
+   },
+   "value": {
+       "body": "your review body here"
+   }
+}
+```
+
+成功すればbodyのstatusにSUCCESSが、それ以外はFAILEDが入る。詳細はErrorsのKey（別途ドキュメント）を参照のこと。

--- a/api-documents/api/v1/responses/error_keys.md
+++ b/api-documents/api/v1/responses/error_keys.md
@@ -1,0 +1,14 @@
+#### post
+
+review_id: reviewのIDが不正な時に返ってきます。
+
+response: レスポンスにレスポンスしようとした時に返ります。
+
+closed: 既にクローズされているPostにレビューを投稿しようとしたとき
+
+body: バリデーションエラー時。messagesの詳細は以下。
+
+- can't be blank
+  - bodyがないかスペースのみなどのとき
+- is too long (maximum is 5000 characters)
+  - bodyの中身がとても長いとき

--- a/api-documents/api/v1/reviews/api.md
+++ b/api-documents/api/v1/reviews/api.md
@@ -1,0 +1,78 @@
+#### post /api/v1/posts/id/reviews
+
+必要なparameterの例
+
+```json
+{
+   "token": {
+             "onetime": "your onetime token here"
+   },
+   "value": {
+       "body": "your review body here"
+   }
+}
+```
+
+成功すればbodyのstatusにSUCCESSが、それ以外はFAILEDが入る。詳細はErrorsのKey（別途ドキュメント）を参照のこと。
+
+#### get /api/v1/posts/id/reviews
+
+URLのidは投稿のID  
+log-inしていなくても見れる。
+
+##### レスポンスの中身の例
+
+```json
+{
+    "status": "SUCCESS",
+    "body": [
+        {
+            "id": 1,
+            "body": "review_body",
+            "created_at": "2020-09-04T10:07:43.484Z",
+            "thrown_coins": 0,
+            "reviewer": {
+                "name": "takashiii",
+                "nickname": "takashiii",
+                "icon": null
+            },
+            "responses": [
+                {
+                    "id": 2,
+                    "body": "reply",
+                    "created_at": "2020-09-04T10:09:18.365Z",
+                    "thrown_coins": 0,
+                    "responder": {
+                        "name": "takashiii",
+                        "nickname": "takashiii",
+                        "icon": null
+                    }
+                },
+                {
+                    "id": 3,
+                    "body": "reply2",
+                    "created_at": "2020-09-04T10:13:08.260Z",
+                    "thrown_coins": 0,
+                    "responder": {
+                        "name": "takashiii",
+                        "nickname": "takashiii",
+                        "icon": null
+                    }
+                }
+            ]
+        },
+        {
+            "id": 4,
+            "body": "review_body",
+            "created_at": "2020-09-04T15:12:49.789Z",
+            "thrown_coins": 0,
+            "reviewer": {
+                "name": "takashiii",
+                "nickname": "takashiii",
+                "icon": null
+            },
+            "responses": []
+        }
+    ]
+}
+```

--- a/api-documents/api/v1/reviews/api.md
+++ b/api-documents/api/v1/reviews/api.md
@@ -16,6 +16,7 @@
 成功すればbodyのstatusにSUCCESSが、それ以外はFAILEDが入る。詳細はErrorsのKey（別途ドキュメント）を参照のこと。
 
 #### get /api/v1/posts/id/reviews
+#### get /api/v1/users/name/reviews
 
 required params
 ```json
@@ -26,6 +27,7 @@ required params
 ```
 
 URLのidは投稿のID  
+URLのnameはユーザーの名前  
 log-inしていなくても見れる。
 
 ##### レスポンスの中身の例

--- a/api-documents/api/v1/reviews/api.md
+++ b/api-documents/api/v1/reviews/api.md
@@ -17,6 +17,14 @@
 
 #### get /api/v1/posts/id/reviews
 
+required params
+```json
+{
+  "page_number": "表示するレビューのページ番号. 何も指定しない場合は1",
+  "max_content": "1ページに表示するレビュー+レスポンスの数. 何も指定しない場合は50"
+}
+```
+
 URLのidは投稿のID  
 log-inしていなくても見れる。
 
@@ -25,54 +33,58 @@ log-inしていなくても見れる。
 ```json
 {
     "status": "SUCCESS",
-    "body": [
-        {
-            "id": 1,
-            "body": "review_body",
-            "created_at": "2020-09-04T10:07:43.484Z",
-            "thrown_coins": 0,
-            "reviewer": {
-                "name": "takashiii",
-                "nickname": "takashiii",
-                "icon": null
-            },
-            "responses": [
-                {
-                    "id": 2,
-                    "body": "reply",
-                    "created_at": "2020-09-04T10:09:18.365Z",
-                    "thrown_coins": 0,
-                    "responder": {
-                        "name": "takashiii",
-                        "nickname": "takashiii",
-                        "icon": null
-                    }
+    "body": {
+        "reviews": [
+            {
+                "id": 1,
+                "body": "review_body",
+                "created_at": "2020-09-04T10:07:43.484Z",
+                "thrown_coins": 0,
+                "reviewer": {
+                    "name": "takashiii",
+                    "nickname": "takashiii",
+                    "icon": null
                 },
-                {
-                    "id": 3,
-                    "body": "reply2",
-                    "created_at": "2020-09-04T10:13:08.260Z",
-                    "thrown_coins": 0,
-                    "responder": {
-                        "name": "takashiii",
-                        "nickname": "takashiii",
-                        "icon": null
+                "responses": [
+                    {
+                        "id": 2,
+                        "body": "reply",
+                        "created_at": "2020-09-04T10:09:18.365Z",
+                        "thrown_coins": 0,
+                        "responder": {
+                            "name": "takashiii",
+                            "nickname": "takashiii",
+                            "icon": null
+                        }
+                    },
+                    {
+                        "id": 3,
+                        "body": "reply2",
+                        "created_at": "2020-09-04T10:13:08.260Z",
+                        "thrown_coins": 0,
+                        "responder": {
+                            "name": "takashiii",
+                            "nickname": "takashiii",
+                            "icon": null
+                        }
                     }
-                }
-            ]
-        },
-        {
-            "id": 4,
-            "body": "review_body",
-            "created_at": "2020-09-04T15:12:49.789Z",
-            "thrown_coins": 0,
-            "reviewer": {
-                "name": "takashiii",
-                "nickname": "takashiii",
-                "icon": null
+                ]
             },
-            "responses": []
-        }
-    ]
+            {
+                "id": 4,
+                "body": "review_body",
+                "created_at": "2020-09-04T15:12:49.789Z",
+                "thrown_coins": 0,
+                "reviewer": {
+                    "name": "takashiii",
+                    "nickname": "takashiii",
+                    "icon": null
+                },
+                "responses": []
+            }
+        ],
+        "total_contents_count": 4,
+        "page_number": 1
+    }
 }
 ```

--- a/api-documents/api/v1/reviews/error_keys.md
+++ b/api-documents/api/v1/reviews/error_keys.md
@@ -1,0 +1,15 @@
+#### get
+特になし(存在しないレビューIDのときも空配列を返す)
+
+#### post
+
+post_id: 存在しないPost_idを指定したとき
+
+closed: 既にクローズされているPostにレビューを投稿しようとしたとき
+
+body: バリデーションエラー時。messagesの詳細は以下。
+
+- can't be blank
+  - bodyがないかスペースのみなどのとき
+- is too long (maximum is 5000 characters)
+  - bodyの中身がとても長いとき

--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Api::V1::ResponsesController < ApplicationController
+  include UserHelper
+
+  before_action :get_user, only: %i[create]
+
+  def create
+    return unless @user
+
+    review = Review.find(review_id)
+
+    unless review
+      message = 'the review is not found'
+      return error_response json: generate_response(FAILED, message)
+                                    .merge(error_messages(key: 'review_id', message: message))
+    end
+
+    post = review.post
+
+    if post.closed?
+      message = 'the post has been closed'
+      return error_response json: generate_response(FAILED, message)
+                                    .merge(error_messages(key: 'closed', message: message))
+    end
+
+    return if response?(review)
+
+    response = review.reply(body: body, user: @user)
+
+    if response.persisted?
+      return render json: generate_response(SUCCESS, 'the response has been created')
+    end
+
+    failed_to_create response
+  end
+
+  private
+
+  def response?(review)
+    if ReviewLink.response?(review)
+      message = 'can not response to a response'
+      error_response json: generate_response(FAILED, message)
+                             .merge(error_messages(key: 'response', message: message))
+      return true
+    end
+    false
+  end
+
+  def review_id
+    return nil unless params[:review_id]
+
+    params.permit(:review_id)[:review_id]
+  end
+
+  def body
+    return nil unless params[:value] && params[:value][:body]
+
+    params.require(:value).permit(:body)[:body]
+  end
+end

--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+# レビューに対するレスポンスを取り扱うためのコントローラー
 class Api::V1::ResponsesController < ApplicationController
   include UserHelper
 
   before_action :get_user, only: %i[create]
 
+  # reviewに対するresponseを作成するメソッド
   def create
     return unless @user
 
@@ -37,6 +39,7 @@ class Api::V1::ResponsesController < ApplicationController
 
   private
 
+  # responseかreviewかを調べるためのメソッド
   def response?(review)
     if ReviewLink.response?(review)
       message = 'can not response to a response'

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class Api::V1::ReviewsController < ApplicationController
+  include UserHelper
+
+  before_action :get_user, only: %i[create]
+  # before_action :get_session_owner, only: %i[show]
+
+  def create
+    return unless @user
+
+    post = Post.find(post_id)
+    unless post
+      message = 'the post is not found'
+      return error_response json: generate_response(FAILED, message)
+                                    .merge(error_messages(key: 'post_id', message: message))
+    end
+
+    if post.closed?
+      message = 'the post has been closed'
+      return error_response json: generate_response(FAILED, message)
+                                    .merge(error_messages(key: 'closed', message: message))
+    end
+
+    review = Review.generate_record(body: body, post: post, user: @user)
+    if review.save
+      return render json: generate_response(SUCCESS, 'the review has been created successfully')
+    end
+
+    failed_to_create review
+  end
+
+  def show
+    body = ShowReview.show(post_id)
+    render json: generate_response(SUCCESS, body)
+  end
+
+  private
+
+  def failed_to_create(response)
+    messages = generate_error_messages_from_errors(response.errors.messages)
+    error_response json: generate_response(FAILED, nil)
+                           .merge(error_messages(error_messages: messages))
+  end
+
+  def post_id
+    return nil unless params[:id]
+
+    params.permit(:id)[:id]
+  end
+
+  def body
+    return nil unless params[:value] && params[:value][:body]
+
+    params.require(:value).permit(:body)[:body]
+  end
+end

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -37,12 +37,6 @@ class Api::V1::ReviewsController < ApplicationController
 
   private
 
-  def failed_to_create(response)
-    messages = generate_error_messages_from_errors(response.errors.messages)
-    error_response json: generate_response(FAILED, nil)
-                           .merge(error_messages(error_messages: messages))
-  end
-
   def post_id
     return nil unless params[:id]
 

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+# レビューに関する操作を集めたコントローラー
 class Api::V1::ReviewsController < ApplicationController
   include UserHelper
 
   before_action :get_user, only: %i[create]
   # before_action :get_session_owner, only: %i[show]
 
+  # postに対するレビューを投稿するメソッド
   def create
     return unless @user
 
@@ -30,6 +32,7 @@ class Api::V1::ReviewsController < ApplicationController
     failed_to_create review
   end
 
+  # postに紐づくレビューとレスポンスを取得するメソッド
   def show
     body = ShowReview.show(post_id)
     render json: generate_response(SUCCESS, body)

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -46,7 +46,7 @@ class Api::V1::ReviewsController < ApplicationController
     comments_count = if user_name
                        Review.count_by_user_name(user_name)
                      else
-                       ShowReview.count_reviews_and_responses(post_id)
+                       Review.count_by_post_id(post_id)
                      end
     results = {
       reviews: reviews_and_responses,

--- a/app/controllers/api/v1/reviews_controller.rb
+++ b/app/controllers/api/v1/reviews_controller.rb
@@ -38,8 +38,16 @@ class Api::V1::ReviewsController < ApplicationController
   # postに紐づくレビューとレスポンスを取得するメソッド
   # 件数も表示する
   def show
-    reviews_and_responses = ShowReview.show(post_id, max_contents_count, page_number)
-    comments_count = ShowReview.count_reviews_and_responses(post_id)
+    reviews_and_responses = if user_name
+                              ShowReview.show_by_user_name(user_name, max_contents_count, page_number)
+                            else
+                              ShowReview.show(post_id, max_contents_count, page_number)
+                            end
+    comments_count = if user_name
+                       Review.count_by_user_name(user_name)
+                     else
+                       ShowReview.count_reviews_and_responses(post_id)
+                     end
     results = {
       reviews: reviews_and_responses,
       total_contents_count: comments_count,
@@ -49,6 +57,12 @@ class Api::V1::ReviewsController < ApplicationController
   end
 
   private
+
+  def user_name
+    return nil unless params[:name]
+
+    params.permit(:name)[:name]
+  end
 
   def post_id
     return nil unless params[:id]

--- a/app/controllers/concerns/coin.rb
+++ b/app/controllers/concerns/coin.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Coinの操作をまとめたモジュール。
+# includeして使うこと。
+module Coin
+  extend ActiveSupport::Concern
+  MAX_TRANSACTION_AMOUNT = 500
+
+  module_function
+
+  # 指定額を自分の財布から引いて相手の財布に送り、その履歴を保存するメソッド
+  # == Args
+  # * amount :: 贈与額(Integer)
+  # * from   :: 渡す側のUserオブジェクト
+  # * to     :: 渡す相手のUserオブジェクト
+  # * review :: 対象のReviewまたはResponseのインスタンス
+  # == Return
+  # * 成功 # => true
+  # * 失敗 # => false
+  def throw(amount:, from:, review:)
+    to = review.user
+    return false if amount.negative? || amount > MAX_TRANSACTION_AMOUNT
+    return false if ReviewCoinTransaction.already_threw?(review_id: review.id, user_id: from.id)
+    return false if from.id == to.id
+
+    to.transaction do
+      to.add_coins(amount)
+      from.take_coins(amount)
+      review.update!(thrown_coins: review.thrown_coins + amount)
+      ReviewCoinTransaction.create_record(review: review, from: from, amount: amount)
+    rescue ActiveRecord::RecordInvalid || ArgumentError
+      return false
+    end
+    true
+  end
+
+  # ユーザーからコインを奪う
+  # ==Arguments
+  # * amount :: Integer
+  # * user   :: Userのインスタンス
+  # ==Return
+  # 成功 # => true
+  # 失敗 # => false
+  def take(amount:, user:)
+    return false if amount.negative?
+
+    begin
+      user.take_coins(amount)
+    rescue ActiveRecord::RecordInvalid || ArgumentError
+      return false
+    end
+    true
+  end
+
+  # ユーザーにコインを授ける
+  # ==Arguments
+  # * amount :: Integer
+  # * user   :: Userのインスタンス
+  # ==Return
+  # 成功 # => true
+  # 失敗 # => false
+  def add(amount:, user:)
+    return false if amount.negative?
+
+    begin
+      user.add_coins(amount)
+    rescue ActiveRecord::RecordInvalid || ArgumentError
+      return false
+    end
+    true
+  end
+end

--- a/app/controllers/concerns/error_message_helper.rb
+++ b/app/controllers/concerns/error_message_helper.rb
@@ -22,4 +22,10 @@ module ErrorMessageHelper
   def error_response(status: 400, json:)
     render status: status, json: json
   end
+
+  def failed_to_create(model)
+    messages = generate_error_messages_from_errors(model.errors.messages)
+    error_response json: generate_response(FAILED, nil)
+                           .merge(error_messages(error_messages: messages))
+  end
 end

--- a/app/controllers/concerns/error_message_helper.rb
+++ b/app/controllers/concerns/error_message_helper.rb
@@ -2,6 +2,7 @@
 
 module ErrorMessageHelper
   extend ActiveSupport::Concern
+  include ResponseStatus
 
   def generate_error_messages_from_errors(messages)
     messages.map do |key, value|
@@ -25,7 +26,7 @@ module ErrorMessageHelper
 
   def failed_to_create(model)
     messages = generate_error_messages_from_errors(model.errors.messages)
-    error_response json: generate_response(FAILED, nil)
+    error_response json: generate_response(ResponseStatus::FAILED, nil)
                            .merge(error_messages(error_messages: messages))
   end
 end

--- a/app/controllers/concerns/user_helper.rb
+++ b/app/controllers/concerns/user_helper.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# ユーザーをトークンから取り出す操作をまとめたモジュール
+module UserHelper
+  extend ActiveSupport::Concern
+  include ResponseStatus
+  include ResponseHelper
+  include LoginHelper
+  include ErrorMessageHelper
+
+  SUCCESS = ResponseStatus::SUCCESS
+  FAILED = ResponseStatus::FAILED
+  ERROR = ResponseStatus::ERROR
+  OLD_TOKEN = ResponseStatus::OLD_TOKEN
+
+  # パラメーターにtokenがあり、かつ、そのトークンがセッションに存在し、期限が切れていなかったら返信パラメーターにis_mine=trueを入れる。
+  # トークンの期限が切れていれば400エラーを発生させる
+  def get_session_owner
+    return unless user_token_from_flat_params
+
+    onetime_session = login?(user_token_from_flat_params)
+    if onetime_session&.available?
+      @session_user = onetime_session.user
+    elsif onetime_session && !onetime_session.available?
+      message = 'onetime token is unavailable'
+      error_response json: generate_response(OLD_TOKEN, message: message)
+                             .merge(error_messages(key: 'token', message: message))
+    end
+  end
+
+  # post, putにおいてネストされたパラメーターからトークンを取り出し、
+  # ログインしていてセッションがまだ有効なら
+  # ユーザーをインスタンス変数に代入する関数
+  def get_user
+    unless user_token_from_nest_params[:onetime]
+      return error_response json: generate_response(FAILED, nil)
+                                    .merge(error_messages(key: 'token', message: 'onetime token is empty'))
+    end
+
+    onetime_session = login?(user_token_from_nest_params[:onetime])
+    unless onetime_session
+      message = 'you are not logged in'
+      return error_response json: generate_response(FAILED, message: message)
+                                    .merge(error_messages(key: 'login', message: message))
+    end
+    unless onetime_session.available?
+      message = 'onetime token is too old'
+      return error_response json: generate_response(OLD_TOKEN, message: message)
+                                    .merge(error_messages(key: 'token', message: message))
+    end
+
+    @user = onetime_session.user
+  end
+
+  # post, put用
+  def user_token_from_nest_params
+    return {} unless params[:token]
+
+    params.require(:token).permit(:onetime)
+  end
+
+  # get, delete用
+  def user_token_from_flat_params
+    return nil unless params[:token]
+
+    params.permit(:token)[:token]
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
   DEFAULT_REWARD = 100
-  DEFINED_STATES = %w[accepting voting resolved].freeze
+  DEFINED_STATES = %w[open closed].freeze
   MAX_REWARD = 500
   MIN_REWARD = 0
   BODY_MAX_CHARS = 10000

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -25,12 +25,12 @@ class Post < ApplicationRecord
     update_attribute(:state, state)
   end
 
-  def resolve
-    change_state('resolved')
+  def close
+    change_state('closed')
   end
 
-  def resolved?
-    state == 'resolved'
+  def closed?
+    state == 'closed'
   end
 
   def ask_to(users)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,13 +6,14 @@ class Post < ApplicationRecord
   BODY_MAX_CHARS = 10000
   CODE_MAX_CHARS = 10000
   TITLE_MAX_CHARS = 100
+  SOURCE_URL_MAX_CHARS = 140
 
   before_save :set_default_reward
   validates :title, presence: true, length: { maximum: TITLE_MAX_CHARS }
   validates :body, presence: true, length: { maximum: BODY_MAX_CHARS }
   validates :code, presence: true, length: { maximum: CODE_MAX_CHARS }
   validates :bestanswer_reward, numericality: { greater_than_or_equal_to: MIN_REWARD, less_than_or_equal_to: MAX_REWARD }, allow_nil: true
-  validates :source_url, presence: true, if: :url_exists?, allow_nil: true
+  validates :source_url, presence: true, length: { maximum: SOURCE_URL_MAX_CHARS }, if: :url_exists?, allow_nil: true
 
   has_many :asked_users, dependent: :destroy
   has_many :reviews, dependent: :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,6 +15,7 @@ class Post < ApplicationRecord
   validates :source_url, presence: true, if: :url_exists?, allow_nil: true
 
   has_many :asked_users, dependent: :destroy
+  has_many :reviews, dependent: :destroy
   belongs_to :user
 
   def change_state(state)

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -28,6 +28,11 @@ class Review < ApplicationRecord
     review
   end
 
+  # post_idに紐づくレビューとレスポンスの数を数える
+  def self.count_by_post_id(post_id)
+    where(post_id: post_id).count
+  end
+
   def self.count_by_user_name(user_name)
     user = User.find_by(name: user_name)
     where(user_id: user ? user.id : nil).count

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# 投稿に紐づくReviewを表すモデル
+# Post has_many Reviews
+# User has_many Reviews
+class Review < ApplicationRecord
+
+  BODY_MAX_CHARS = 5000
+
+  belongs_to :post
+  belongs_to :user
+  has_many :review_coin_transactions, dependent: :destroy
+
+  validates :body, presence: true, length: { maximum: BODY_MAX_CHARS }
+
+  # 渡されたUserとPostをもとにReviewオブジェクトを生成して返す
+  # == Args
+  # * body    :: 本文
+  # * user    :: Userオブジェクト
+  # * post    :: Postオブジェクト
+  # * primary :: boolean(レビューかレスポンスか)
+  # == Return
+  # 生成されたReviewオブジェクト
+  def self.generate_record(body:, user:, post:, primary: true)
+    review = post.reviews.new(body: body)
+    review.user = user
+    review.primary = primary
+    review
+  end
+
+  # 対象のレビューに指定のユーザーがリプライをするメソッド
+  # ==Arguments
+  # * review :: Review
+  # * body   :: String
+  # * user   :: User
+  # ==Return
+  # 成功 # => Review
+  # 失敗 # => ActiveRecord::RecordInvalid | ArgumentError
+  def reply(body:, user:)
+    if ReviewLink.response?(self)
+      raise ArgumentError, 'can not response to response'
+    end
+
+    post = self.post
+    response = Review.generate_record(body: body, user: user, post: post, primary: false)
+
+    transaction do
+      response.save!
+      ReviewLink.create!(from: id, to: response.id)
+    end
+    response
+  end
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -28,6 +28,11 @@ class Review < ApplicationRecord
     review
   end
 
+  def self.count_by_user_name(user_name)
+    user = User.find_by(name: user_name)
+    where(user_id: user ? user.id : nil).count
+  end
+
   # 対象のレビューに指定のユーザーがリプライをするメソッド
   # ==Arguments
   # * body   :: String

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -33,8 +33,8 @@ class Review < ApplicationRecord
   # * body   :: String
   # * user   :: User
   # ==Return
-  # 成功 # => Review
-  # 失敗 # => ActiveRecord::RecordInvalid | ArgumentError
+  # 成功またはRecordInvalid # => Review
+  # 失敗(レスポンスにレスしようとした) # => ArgumentError
   def reply(body:, user:)
     if ReviewLink.response?(self)
       raise ArgumentError, 'can not response to response'
@@ -46,6 +46,8 @@ class Review < ApplicationRecord
     transaction do
       response.save!
       ReviewLink.create!(from: id, to: response.id)
+    rescue ActiveRecord::RecordInvalid
+      return response
     end
     response
   end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -30,7 +30,6 @@ class Review < ApplicationRecord
 
   # 対象のレビューに指定のユーザーがリプライをするメソッド
   # ==Arguments
-  # * review :: Review
   # * body   :: String
   # * user   :: User
   # ==Return

--- a/app/models/review_coin_transaction.rb
+++ b/app/models/review_coin_transaction.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# レビューに対するコインの取引
+class ReviewCoinTransaction < ApplicationRecord
+  validates :review_id, uniqueness: { scope: :from }
+
+  belongs_to :review
+
+  # 既にそのレビューに対して投げ銭をしているか確認
+  # ==Arguments
+  # * review_id :: 調べるレビューのID
+  # * user_id   :: 調べる渡したユーザーのID
+  # ==Return
+  # * 存在している   # => true
+  # * 存在していない # => false
+  def self.already_threw?(review_id:, user_id:)
+    exists?(review_id: review_id, from: user_id)
+  end
+
+  # 取引履歴を作成する
+  # ==Arguments
+  # * review :: Reviewのインスタンス
+  # * from   :: Userのインスタンス
+  # * amount :: 取引額(Integer)
+  # ==Return
+  # * 成功 # => self
+  # * 失敗 # => 例外を返す(引数が足りなかったりなど)
+  def self.create_record(review:, from:, amount:)
+    raise ArgumentError if amount.negative?
+
+    to = review.user
+    coin_transaction = new(from: from.id, to: to.id, amount: amount)
+    coin_transaction.review = review
+    coin_transaction.save!
+    coin_transaction
+  end
+end

--- a/app/models/review_link.rb
+++ b/app/models/review_link.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ReviewLink < ApplicationRecord
+  # レスポンスにレスポンスをすることはできない仕様なので、そのチェック
+  # ==Argument
+  # * review :: Review
+  # ==Response
+  # レビューのレスポンス # => true
+  # レビュー # => false
+  def self.response?(review)
+    ReviewLink.exists?(to: review.id)
+  end
+end

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -67,11 +67,6 @@ class ShowReview < ApplicationRecord
     merge_responses_to_reviews(reviews, responses)
   end
 
-  # post_idに紐づくレビューとレスポンスの数を数える
-  def self.count_reviews_and_responses(post_id)
-    where(post_id: post_id).count
-  end
-
   private
 
   def self.merge_responses_to_reviews(reviews, responses)

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -21,7 +21,7 @@
 # * response_thrown_coins :: integer
 class ShowReview < ApplicationRecord
   DEFAULT_MAX_CONTENTS_COUNT = 50
-  # ポストに紐づくレビューとレスポンスを表現したハッシュを返す
+  # ポストに紐づくレビューとレスポンスを表現したハッシュの配列を返す
   # ==Argument
   # * post_id      :: integer
   # * max_contents :: 1ページに表示するコンテンツ量(integer)

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -59,6 +59,14 @@ class ShowReview < ApplicationRecord
     merge_responses_to_reviews(reviews, responses)
   end
 
+  # 上のshowのuser_name版。
+  def self.show_by_user_name(user_name, max_contents = DEFAULT_MAX_CONTENTS_COUNT, page = 1)
+    reviews_responses_mix = where(reviewer_name: user_name).or(where(responder_name: user_name))
+                              .offset(max_contents * (page - 1)).limit(max_contents)
+    reviews, responses = split_reviews_and_responses(reviews_responses_mix)
+    merge_responses_to_reviews(reviews, responses)
+  end
+
   # post_idに紐づくレビューとレスポンスの数を数える
   def self.count_reviews_and_responses(post_id)
     where(post_id: post_id).count

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -40,7 +40,7 @@ class ShowReview < ApplicationRecord
   #       body,
   #       created_at,
   #       thrown_coins,
-  #       reviewer: {
+  #       responder: {
   #         name,
   #         nickname,
   #         icon

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -20,9 +20,12 @@
 # * responder_icon
 # * response_thrown_coins :: integer
 class ShowReview < ApplicationRecord
+  DEFAULT_MAX_CONTENTS_COUNT = 50
   # ポストに紐づくレビューとレスポンスを表現したハッシュを返す
   # ==Argument
-  # * post_id :: integer
+  # * post_id      :: integer
+  # * max_contents :: 1ページに表示するコンテンツ量(integer)
+  # * page         :: 何ページ目を表示するか(integer)
   # ==Returns
   # [
   #   {
@@ -50,10 +53,15 @@ class ShowReview < ApplicationRecord
   #   }
   # ]
   #
-  def self.show(post_id)
-    reviews_responses_mix = where(post_id: post_id)
+  def self.show(post_id, max_contents = DEFAULT_MAX_CONTENTS_COUNT, page = 1)
+    reviews_responses_mix = where(post_id: post_id).offset(max_contents * (page - 1)).limit(max_contents)
     reviews, responses = split_reviews_and_responses(reviews_responses_mix)
     merge_responses_to_reviews(reviews, responses)
+  end
+
+  # post_idに紐づくレビューとレスポンスの数を数える
+  def self.count_reviews_and_responses(post_id)
+    where(post_id: post_id).count
   end
 
   private

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# reviewsとlink_reviewsをjoinした結果のビュー。
+# ==Columns
+# * post_id               :: integer
+# * review_id             :: string
+# * review_body           :: string
+# * review_created_at     :: date
+# * reviewer_id           :: string
+# * reviewer_name
+# * reviewer_nickname
+# * reviewer_icon
+# * review_thrown_coins   :: integer
+# * response_id           :: integer
+# * response_body         :: string
+# * response_created_at   :: date
+# * responder_id          :: integer
+# * responder_name
+# * responder_nickname
+# * responder_icon
+# * response_thrown_coins :: integer
+class ShowReview < ApplicationRecord
+  # ポストに紐づくレビューとレスポンスを表現したハッシュを返す
+  # ==Argument
+  # * post_id :: integer
+  # ==Returns
+  # [
+  #   {
+  #     id,
+  #     body,
+  #     created_at,
+  #     thrown_coins,
+  #     reviewer: {
+  #       name,
+  #       nickname,
+  #       icon
+  #     }
+  #     responses: [{
+  #       id,
+  #       body,
+  #       created_at,
+  #       thrown_coins,
+  #       reviewer: {
+  #         name,
+  #         nickname,
+  #         icon
+  #       },
+  #       ...
+  #     }]
+  #   }
+  # ]
+  #
+  def self.show(post_id)
+    reviews_responses_mix = where(post_id: post_id)
+    reviews, responses = split_reviews_and_responses(reviews_responses_mix)
+    merge_responses_to_reviews(reviews, responses)
+  end
+
+  private
+
+  def self.merge_responses_to_reviews(reviews, responses)
+    reviews.map do |id, review|
+      review.merge(responses: responses[id] || [])
+    end
+  end
+
+  def self.split_reviews_and_responses(reviews_responses_mix)
+    reviews = {}
+    responses = {}
+    reviews_responses_mix.each do |review_response_mix|
+      current_review_id = review_response_mix.review_id
+
+      reviews[current_review_id] = generate_review(review_response_mix)
+
+      next unless review_response_mix.response_id
+
+      responses[current_review_id] ||= []
+      responses[current_review_id].push generate_response(review_response_mix)
+
+    end
+    [reviews, responses]
+  end
+
+  def self.generate_review(review_response_mix)
+    {
+      id: review_response_mix.review_id,
+      body: review_response_mix.review_body,
+      created_at: review_response_mix.review_created_at,
+      thrown_coins: review_response_mix.review_thrown_coins,
+      reviewer: {
+        name: review_response_mix.reviewer_name,
+        nickname: review_response_mix.reviewer_nickname,
+        icon: icon_url(review_response_mix.reviewer_id, review_response_mix.reviewer_icon)
+      }
+    }
+  end
+
+  def self.generate_response(review_response_mix)
+    {
+      id: review_response_mix.response_id,
+      body: review_response_mix.response_body,
+      created_at: review_response_mix.response_created_at,
+      thrown_coins: review_response_mix.response_thrown_coins,
+      responder: {
+        name: review_response_mix.responder_name,
+        nickname: review_response_mix.responder_nickname,
+        icon: icon_url(review_response_mix.responder_id, review_response_mix.responder_icon)
+      }
+    }
+  end
+
+  # ディレクトリそのまま書いてるのどうにかならないのかなと思いつつどうにもならなさそう
+  def self.icon_url(user_id, file_name)
+    return nil unless file_name
+
+    "/uploads/user/icon/#{user_id}/#{file_name}"
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,8 @@ module Fourecode
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.active_record.schema_format = :sql
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       # routing for reviews and responses
       get '/posts/:id/reviews', to: 'reviews#show'
       post '/posts/:id/reviews', to: 'reviews#create'
+      post '/posts/:id/reviews/:review_id', to: 'responses#create'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
       # routing for reviews and responses
       get '/posts/:id/reviews', to: 'reviews#show'
+      get '/users/:name/reviews', to: 'reviews#show'
       post '/posts/:id/reviews', to: 'reviews#create'
       post '/posts/:id/reviews/:review_id', to: 'responses#create'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,10 @@ Rails.application.routes.draw do
       put '/password_resets', to: 'password_resets#update'
       get '/search/posts', to: 'posts_searches#search'
       get '/search/users', to: 'users_searches#search'
+
+      # routing for reviews and responses
+      get '/posts/:id/reviews', to: 'reviews#show'
+      post '/posts/:id/reviews', to: 'reviews#create'
     end
   end
 end

--- a/db/migrate/20200901015235_create_reviews.rb
+++ b/db/migrate/20200901015235_create_reviews.rb
@@ -1,0 +1,13 @@
+class CreateReviews < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reviews do |t|
+      t.text :body
+      t.integer :thrown_coins, default: 0
+
+      t.string :user_id
+      t.references :post, foreign_key: true
+      t.timestamps
+    end
+    add_foreign_key :reviews, :users
+  end
+end

--- a/db/migrate/20200901030647_change_default_post_state.rb
+++ b/db/migrate/20200901030647_change_default_post_state.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultPostState < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :posts, :state, from: :accepting, to: :open
+  end
+end

--- a/db/migrate/20200901113634_create_review_coin_transactions.rb
+++ b/db/migrate/20200901113634_create_review_coin_transactions.rb
@@ -1,0 +1,13 @@
+class CreateReviewCoinTransactions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :review_coin_transactions do |t|
+      t.string :from
+      t.string :to
+      t.references :review, foreign_key: true
+      t.integer :amount
+      t.timestamps
+    end
+    add_foreign_key :review_coin_transactions, :users, { column: :from }
+    add_foreign_key :review_coin_transactions, :users, { column: :to }
+  end
+end

--- a/db/migrate/20200901123706_add_coins_to_users.rb
+++ b/db/migrate/20200901123706_add_coins_to_users.rb
@@ -1,0 +1,5 @@
+class AddCoinsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :coins, :integer
+  end
+end

--- a/db/migrate/20200902094116_create_review_links.rb
+++ b/db/migrate/20200902094116_create_review_links.rb
@@ -1,0 +1,11 @@
+class CreateReviewLinks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :review_links do |t|
+      t.integer :from
+      t.integer :to
+      t.timestamps
+    end
+    add_foreign_key :review_links, :reviews, { column: :from }
+    add_foreign_key :review_links, :reviews, { column: :to }
+  end
+end

--- a/db/migrate/20200902133349_add_primary_to_column_of_review.rb
+++ b/db/migrate/20200902133349_add_primary_to_column_of_review.rb
@@ -1,0 +1,5 @@
+class AddPrimaryToColumnOfReview < ActiveRecord::Migration[6.0]
+  def change
+    add_column :reviews, :primary, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_135639) do
+ActiveRecord::Schema.define(version: 2020_09_01_015235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,16 @@ ActiveRecord::Schema.define(version: 2020_08_25_135639) do
     t.index ["title"], name: "index_posts_on_title"
   end
 
+  create_table "reviews", force: :cascade do |t|
+    t.text "body"
+    t.integer "thrown_coins", default: 0
+    t.string "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_reviews_on_post_id"
+  end
+
   create_table "users", id: :string, limit: 36, force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -83,4 +93,6 @@ ActiveRecord::Schema.define(version: 2020_08_25_135639) do
   add_foreign_key "onetime_sessions", "users"
   add_foreign_key "password_reset_sessions", "users"
   add_foreign_key "posts", "users"
+  add_foreign_key "reviews", "posts"
+  add_foreign_key "reviews", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_030647) do
+ActiveRecord::Schema.define(version: 2020_09_04_004231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,23 @@ ActiveRecord::Schema.define(version: 2020_09_01_030647) do
     t.index ["title"], name: "index_posts_on_title"
   end
 
+  create_table "review_coin_transactions", force: :cascade do |t|
+    t.string "from"
+    t.string "to"
+    t.bigint "review_id"
+    t.integer "amount"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["review_id"], name: "index_review_coin_transactions_on_review_id"
+  end
+
+  create_table "review_links", force: :cascade do |t|
+    t.integer "from"
+    t.integer "to"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "reviews", force: :cascade do |t|
     t.text "body"
     t.integer "thrown_coins", default: 0
@@ -68,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_030647) do
     t.bigint "post_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "primary"
     t.index ["post_id"], name: "index_reviews_on_post_id"
   end
 
@@ -84,6 +102,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_030647) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "icon"
     t.string "explanation"
+    t.integer "coins"
   end
 
   add_foreign_key "asked_users", "posts"
@@ -93,6 +112,11 @@ ActiveRecord::Schema.define(version: 2020_09_01_030647) do
   add_foreign_key "onetime_sessions", "users"
   add_foreign_key "password_reset_sessions", "users"
   add_foreign_key "posts", "users"
+  add_foreign_key "review_coin_transactions", "reviews"
+  add_foreign_key "review_coin_transactions", "users", column: "from"
+  add_foreign_key "review_coin_transactions", "users", column: "to"
+  add_foreign_key "review_links", "reviews", column: "from"
+  add_foreign_key "review_links", "reviews", column: "to"
   add_foreign_key "reviews", "posts"
   add_foreign_key "reviews", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_015235) do
+ActiveRecord::Schema.define(version: 2020_09_01_030647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_015235) do
     t.string "title"
     t.integer "bestanswer_reward"
     t.string "source_url"
-    t.string "state", default: "accepting"
+    t.string "state", default: "open"
     t.text "body"
     t.text "code"
     t.datetime "created_at", precision: 6, null: false

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,0 +1,686 @@
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'EUC_JP';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ar_internal_metadata (
+    key character varying NOT NULL,
+    value character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: asked_users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.asked_users (
+    id bigint NOT NULL,
+    user_id character varying,
+    post_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: asked_users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.asked_users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: asked_users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.asked_users_id_seq OWNED BY public.asked_users.id;
+
+
+--
+-- Name: master_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.master_sessions (
+    id bigint NOT NULL,
+    user_id character varying,
+    token_digest character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: master_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.master_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: master_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.master_sessions_id_seq OWNED BY public.master_sessions.id;
+
+
+--
+-- Name: onetime_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.onetime_sessions (
+    id bigint NOT NULL,
+    user_id character varying,
+    token_digest character varying,
+    master_session_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: onetime_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.onetime_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: onetime_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.onetime_sessions_id_seq OWNED BY public.onetime_sessions.id;
+
+
+--
+-- Name: password_reset_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.password_reset_sessions (
+    id bigint NOT NULL,
+    user_id character varying,
+    token_digest character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: password_reset_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.password_reset_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: password_reset_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.password_reset_sessions_id_seq OWNED BY public.password_reset_sessions.id;
+
+
+--
+-- Name: posts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.posts (
+    id bigint NOT NULL,
+    title character varying,
+    bestanswer_reward integer,
+    source_url character varying,
+    state character varying DEFAULT 'open'::character varying,
+    body text,
+    code text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    user_id character varying
+);
+
+
+--
+-- Name: posts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.posts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: posts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.posts_id_seq OWNED BY public.posts.id;
+
+
+--
+-- Name: review_coin_transactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.review_coin_transactions (
+    id bigint NOT NULL,
+    "from" character varying,
+    "to" character varying,
+    review_id bigint,
+    amount integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: review_coin_transactions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.review_coin_transactions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: review_coin_transactions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.review_coin_transactions_id_seq OWNED BY public.review_coin_transactions.id;
+
+
+--
+-- Name: review_links; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.review_links (
+    id bigint NOT NULL,
+    "from" integer,
+    "to" integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: review_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.review_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: review_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.review_links_id_seq OWNED BY public.review_links.id;
+
+
+--
+-- Name: reviews; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reviews (
+    id bigint NOT NULL,
+    body text,
+    thrown_coins integer DEFAULT 0,
+    user_id character varying,
+    post_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    "primary" boolean
+);
+
+
+--
+-- Name: reviews_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.reviews_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: reviews_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.reviews_id_seq OWNED BY public.reviews.id;
+
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.schema_migrations (
+    version character varying NOT NULL
+);
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id character varying(36) NOT NULL,
+    name character varying,
+    email character varying,
+    password_digest character varying,
+    nickname character varying,
+    admin boolean DEFAULT false,
+    activation_digest character varying,
+    activated boolean,
+    activated_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    icon character varying,
+    explanation character varying,
+    coins integer
+);
+
+
+--
+-- Name: show_reviews; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.show_reviews AS
+ SELECT posts.id AS post_id,
+    review.id AS review_id,
+    review.body AS review_body,
+    review.created_at AS review_created_at,
+    review.thrown_coins AS review_thrown_coins,
+    review.user_id AS reviewer_id,
+    reviewer.name AS reviewer_name,
+    reviewer.nickname AS reviewer_nickname,
+    reviewer.icon AS reviewer_icon,
+    response.id AS response_id,
+    response.body AS response_body,
+    response.created_at AS response_created_at,
+    response.thrown_coins AS response_thrown_coins,
+    response.user_id AS responder_id,
+    responder.name AS responder_name,
+    responder.nickname AS responder_nickname,
+    responder.icon AS responder_icon
+   FROM (((((public.posts
+     LEFT JOIN public.reviews review ON ((review.post_id = posts.id)))
+     LEFT JOIN public.users reviewer ON (((reviewer.id)::text = (review.user_id)::text)))
+     LEFT JOIN public.review_links ON ((review.id = review_links."from")))
+     LEFT JOIN public.reviews response ON ((response.id = review_links."to")))
+     LEFT JOIN public.users responder ON (((responder.id)::text = (response.user_id)::text)))
+  WHERE (review."primary" = true)
+  ORDER BY review.created_at, response.created_at;
+
+
+--
+-- Name: asked_users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.asked_users ALTER COLUMN id SET DEFAULT nextval('public.asked_users_id_seq'::regclass);
+
+
+--
+-- Name: master_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.master_sessions ALTER COLUMN id SET DEFAULT nextval('public.master_sessions_id_seq'::regclass);
+
+
+--
+-- Name: onetime_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.onetime_sessions ALTER COLUMN id SET DEFAULT nextval('public.onetime_sessions_id_seq'::regclass);
+
+
+--
+-- Name: password_reset_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.password_reset_sessions ALTER COLUMN id SET DEFAULT nextval('public.password_reset_sessions_id_seq'::regclass);
+
+
+--
+-- Name: posts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.posts ALTER COLUMN id SET DEFAULT nextval('public.posts_id_seq'::regclass);
+
+
+--
+-- Name: review_coin_transactions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coin_transactions ALTER COLUMN id SET DEFAULT nextval('public.review_coin_transactions_id_seq'::regclass);
+
+
+--
+-- Name: review_links id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_links ALTER COLUMN id SET DEFAULT nextval('public.review_links_id_seq'::regclass);
+
+
+--
+-- Name: reviews id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reviews ALTER COLUMN id SET DEFAULT nextval('public.reviews_id_seq'::regclass);
+
+
+--
+-- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ar_internal_metadata
+    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: asked_users asked_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.asked_users
+    ADD CONSTRAINT asked_users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: master_sessions master_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.master_sessions
+    ADD CONSTRAINT master_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: onetime_sessions onetime_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.onetime_sessions
+    ADD CONSTRAINT onetime_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: password_reset_sessions password_reset_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.password_reset_sessions
+    ADD CONSTRAINT password_reset_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: posts posts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.posts
+    ADD CONSTRAINT posts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: review_coin_transactions review_coin_transactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coin_transactions
+    ADD CONSTRAINT review_coin_transactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: review_links review_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_links
+    ADD CONSTRAINT review_links_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reviews reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reviews
+    ADD CONSTRAINT reviews_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_asked_users_on_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_asked_users_on_post_id ON public.asked_users USING btree (post_id);
+
+
+--
+-- Name: index_onetime_sessions_on_master_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_onetime_sessions_on_master_session_id ON public.onetime_sessions USING btree (master_session_id);
+
+
+--
+-- Name: index_posts_on_body; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_body ON public.posts USING btree (body);
+
+
+--
+-- Name: index_posts_on_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_code ON public.posts USING btree (code);
+
+
+--
+-- Name: index_posts_on_title; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_title ON public.posts USING btree (title);
+
+
+--
+-- Name: index_review_coin_transactions_on_review_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_review_coin_transactions_on_review_id ON public.review_coin_transactions USING btree (review_id);
+
+
+--
+-- Name: index_reviews_on_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_reviews_on_post_id ON public.reviews USING btree (post_id);
+
+
+--
+-- Name: onetime_sessions fk_rails_1428a351ac; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.onetime_sessions
+    ADD CONSTRAINT fk_rails_1428a351ac FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: asked_users fk_rails_39ba0f630e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.asked_users
+    ADD CONSTRAINT fk_rails_39ba0f630e FOREIGN KEY (post_id) REFERENCES public.posts(id);
+
+
+--
+-- Name: master_sessions fk_rails_54bfde8022; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.master_sessions
+    ADD CONSTRAINT fk_rails_54bfde8022 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: posts fk_rails_5b5ddfd518; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.posts
+    ADD CONSTRAINT fk_rails_5b5ddfd518 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: review_links fk_rails_7233df4717; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_links
+    ADD CONSTRAINT fk_rails_7233df4717 FOREIGN KEY ("from") REFERENCES public.reviews(id);
+
+
+--
+-- Name: reviews fk_rails_74a66bd6c5; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reviews
+    ADD CONSTRAINT fk_rails_74a66bd6c5 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: review_coin_transactions fk_rails_a45d8b3f22; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coin_transactions
+    ADD CONSTRAINT fk_rails_a45d8b3f22 FOREIGN KEY ("to") REFERENCES public.users(id);
+
+
+--
+-- Name: reviews fk_rails_a4cffdde38; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reviews
+    ADD CONSTRAINT fk_rails_a4cffdde38 FOREIGN KEY (post_id) REFERENCES public.posts(id);
+
+
+--
+-- Name: review_coin_transactions fk_rails_ab46003f6a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coin_transactions
+    ADD CONSTRAINT fk_rails_ab46003f6a FOREIGN KEY (review_id) REFERENCES public.reviews(id);
+
+
+--
+-- Name: onetime_sessions fk_rails_b8f193c7f1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.onetime_sessions
+    ADD CONSTRAINT fk_rails_b8f193c7f1 FOREIGN KEY (master_session_id) REFERENCES public.master_sessions(id);
+
+
+--
+-- Name: review_coin_transactions fk_rails_dcb402afe8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coin_transactions
+    ADD CONSTRAINT fk_rails_dcb402afe8 FOREIGN KEY ("from") REFERENCES public.users(id);
+
+
+--
+-- Name: password_reset_sessions fk_rails_dd09dd6855; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.password_reset_sessions
+    ADD CONSTRAINT fk_rails_dd09dd6855 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: review_links fk_rails_e1d045a493; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_links
+    ADD CONSTRAINT fk_rails_e1d045a493 FOREIGN KEY ("to") REFERENCES public.reviews(id);
+
+
+--
+-- Name: asked_users fk_rails_f27d95bd0d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.asked_users
+    ADD CONSTRAINT fk_rails_f27d95bd0d FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+SET search_path TO "$user", public;
+
+INSERT INTO "schema_migrations" (version) VALUES
+('20200807145129'),
+('20200807154520'),
+('20200807173416'),
+('20200810210809'),
+('20200811145804'),
+('20200814115929'),
+('20200820034203'),
+('20200820070623'),
+('20200825135639'),
+('20200901015235'),
+('20200901030647'),
+('20200901113634'),
+('20200901123706'),
+('20200902094116'),
+('20200902133349');
+
+

--- a/lib/tasks/create_view.rake
+++ b/lib/tasks/create_view.rake
@@ -2,7 +2,7 @@ namespace :db do
   desc 'create ShowReview of view'
   task create_view: :environment do
     ActiveRecord::Base.connection.execute <<-SQL
-      create view show_reviews as
+      create view join_reviews as
       select posts.id as post_id, review.id as review_id, review.body as review_body, review.created_at as review_created_at, review.thrown_coins as review_thrown_coins,
       review.user_id as reviewer_id, reviewer.name as reviewer_name, reviewer.nickname as reviewer_nickname, reviewer.icon as reviewer_icon,
       response.id as response_id, response.body as response_body, response.created_at as response_created_at, response.thrown_coins as response_thrown_coins,
@@ -26,11 +26,30 @@ namespace :db do
       	on responder.id = response.user_id
       where review.primary = true
       order by review.created_at, response.created_at;
+
+      create view show_reviews as
+      select post_id, review_id, review_body, review_created_at, review_thrown_coins,
+      reviewer_id, reviewer_name, reviewer_nickname, reviewer_icon,
+      response_id, response_body, response_created_at, response_thrown_coins,
+      responder_id, responder_name, responder_nickname, responder_icon
+      from(select * from join_reviews union
+      select join_reviews.post_id,
+        join_reviews.review_id, join_reviews.review_body,
+        join_reviews.review_created_at, join_reviews.review_thrown_coins,
+        join_reviews.reviewer_id, join_reviews.reviewer_name,
+        join_reviews.reviewer_nickname, join_reviews.reviewer_icon,
+        null as response_id, null as response_body, null as response_created_at,
+        null as response_thrown_coins, null as responder_id, null as responder_name,
+        null as responder_nickname, null as responder_icon
+      from join_reviews
+      where join_reviews.response_id is not null) as result
+      order by result.review_created_at, result.response_created_at nulls first;
     SQL
   end
   task drop_view: :environment do
     ActiveRecord::Base.connection.execute <<-SQL
       drop view show_reviews;
+      drop view join_reviews;
     SQL
   end
 end

--- a/lib/tasks/create_view.rake
+++ b/lib/tasks/create_view.rake
@@ -1,0 +1,36 @@
+namespace :db do
+  desc 'create ShowReview of view'
+  task create_view: :environment do
+    ActiveRecord::Base.connection.execute <<-SQL
+      create view show_reviews as
+      select posts.id as post_id, review.id as review_id, review.body as review_body, review.created_at as review_created_at, review.thrown_coins as review_thrown_coins,
+      review.user_id as reviewer_id, reviewer.name as reviewer_name, reviewer.nickname as reviewer_nickname, reviewer.icon as reviewer_icon,
+      response.id as response_id, response.body as response_body, response.created_at as response_created_at, response.thrown_coins as response_thrown_coins,
+      response.user_id as responder_id, responder.name as responder_name, responder.nickname as responder_nickname, responder.icon as responder_icon
+      from
+      	posts
+      left outer join
+      	reviews as review
+      	on review.post_id = posts.id
+      left outer join
+      	users as reviewer
+      	on reviewer.id = review.user_id
+      left outer join
+      	review_links
+      	on review.id = review_links.from
+      left outer join
+      	reviews as response
+      	on response.id = review_links.to
+      left outer join
+      	users as responder
+      	on responder.id = response.user_id
+      where review.primary = true
+      order by review.created_at, response.created_at;
+    SQL
+  end
+  task drop_view: :environment do
+    ActiveRecord::Base.connection.execute <<-SQL
+      drop view show_reviews;
+    SQL
+  end
+end

--- a/test/controllers/coin_controller_test.rb
+++ b/test/controllers/coin_controller_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class CoinControllerTest < ActiveSupport::TestCase
+  include Coin
+
+  def setup
+    @email = 'hoge@email.com'
+    @to = User.new(name: 'hoge',
+                   nickname: 'hogechan',
+                   email: @email,
+                   password: 'hogefuga')
+    @to.save
+
+    @email2 = 'hogehoge@email.com'
+    @from = User.new(name: 'fuga',
+                     nickname: 'fuga',
+                     email: @email2,
+                     password: 'hogefuga')
+    @from.save
+
+    @post = @from.posts.new
+    @post.source_url = 'http://hogehoge.com/hoge'
+    @post.body = 'この命名、きれい？'
+    @post.code = 'puts hello'
+    @post.title = 'meimei'
+    @post.bestanswer_reward = 100
+
+    @post.save
+
+    @review = Review.generate_record(body: 'hoge', user: @to, post: @post)
+    @review.save
+  end
+
+  test 'should be thrown' do
+    assert Coin.throw(amount: 100, from: @from, review: @review)
+  end
+
+  test 'can not throw coin to same review twice' do
+    assert Coin.throw(amount: 100, from: @from, review: @review)
+    assert_not Coin.throw(amount: 100, from: @from, review: @review)
+  end
+
+  test 'should be failed' do
+    # 自分に投げる
+    assert_not Coin.throw(amount: 100, from: @to, review: @review)
+    # 限界以上に投げる
+    assert_not Coin.throw(amount: Coin::MAX_TRANSACTION_AMOUNT + 1, from: @from, review: @review)
+  end
+
+  test 'user coins should not be negative' do
+    6.times.each do
+      review = Review.generate_record(body: 'hoge', user: @to, post: @post)
+      review.save
+      assert Coin.throw(amount: 500, from: @from, review: review)
+    end
+    assert_not Coin.throw(amount: 100, from: @from, review: @review)
+  end
+
+  test 'should be taken from the user' do
+    assert Coin.take(amount: 100, user: @from)
+    assert @from.coins == User::DEFAULT_COINS - 100
+  end
+
+  test 'can not take too many coins from the user' do
+    assert_not Coin.take(amount: User::DEFAULT_COINS + 1, user: @from)
+  end
+
+  test 'can not take minus amount of coins from users' do
+    assert_not Coin.take(amount: -100, user: @from)
+  end
+
+  test 'a gift for you' do
+    assert Coin.add(user: @from, amount: 100)
+  end
+
+  test 'a invalid gift for you' do
+    assert_not Coin.add(user: @from, amount: -100)
+  end
+end

--- a/test/controllers/coin_controller_test.rb
+++ b/test/controllers/coin_controller_test.rb
@@ -76,4 +76,10 @@ class CoinControllerTest < ActiveSupport::TestCase
   test 'a invalid gift for you' do
     assert_not Coin.add(user: @from, amount: -100)
   end
+
+  test 'should not be valid' do
+    assert_not Coin.add(user: @from, amount: 3.4)
+    assert_not Coin.take(user: @from, amount: 3.4)
+    assert_not Coin.throw(amount: 10.3, from: @from, review: @review)
+  end
 end

--- a/test/controllers/responses_controller_test.rb
+++ b/test/controllers/responses_controller_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class ResponsesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+  def setup
+    @email = 'hoge@email.com'
+    @user = User.new(name: 'hoge',
+                     nickname: 'hogechan',
+                     email: @email,
+                     password: 'hogefuga')
+    @user.save
+    @user.activate
+
+    @post = @user.posts.create(title: 'test', body: 'test', code: 'test', source_url: 'test')
+    @review = Review.generate_record(body: 'review', user: @user, post: @post)
+    @review.save
+  end
+
+  def create_sessions
+    master_session = @user.master_session.create
+    onetime_session = master_session.onetime_session.new
+    onetime_session.user = @user
+    onetime_session.save
+    [master_session, onetime_session]
+  end
+
+  def get_body
+    @body = JSON.parse(response.body)
+  end
+
+  test 'should be created' do
+    m, o = create_sessions
+    text = 'awesome review'
+    post "/api/v1/posts/#{@post.id}/reviews/#{@review.id}", params: { value: { body: text }, token: { onetime: o.token } }
+    get_body
+    assert @body['status'] == 'SUCCESS'
+  end
+
+  test 'closed post should reject to post response' do
+    @post.close
+
+    m, o = create_sessions
+    text = 'awesome review'
+    post "/api/v1/posts/#{@post.id}/reviews/#{@review.id}", params: { value: { body: text }, token: { onetime: o.token } }
+    get_body
+    assert @body['status'] == 'FAILED'
+    assert @body['errors'].first['key'] == 'closed'
+  end
+
+  test 'can not response to response' do
+    response = @review.reply(user: @user, body: 'body')
+
+    m, o = create_sessions
+    text = 'awesome review'
+    post "/api/v1/posts/#{@post.id}/reviews/#{response.id}", params: { value: { body: text }, token: { onetime: o.token } }
+    get_body
+    assert @body['status'] == 'FAILED'
+    assert @body['errors'].first['key'] == 'response'
+  end
+end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -34,8 +34,9 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
   test 'reviews and responses should be shown' do
     get "/api/v1/posts/#{@post.id}/reviews", params: {}
     get_body
-    assert @body['body'].first['id'] == @review.id
-    assert @body['body'].first['responses'].first['id'] == @res.id
+    assert @body['body']['reviews'].first['id'] == @review.id
+    assert @body['body']['reviews'].first['responses'].first['id'] == @res.id
+    assert @body['body']['total_contents_count'] == 1
   end
 
   test 'should be created' do

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class ReviewsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+  def setup
+    @email = 'hoge@email.com'
+    @user = User.new(name: 'hoge',
+                     nickname: 'hogechan',
+                     email: @email,
+                     password: 'hogefuga')
+    @user.save
+    @user.activate
+
+    @post = @user.posts.create(title: 'test', body: 'test', code: 'test', source_url: 'test')
+    @review = Review.generate_record(body: 'review', user: @user, post: @post)
+    @review.save
+    @res = @review.reply(body: 'reply', user: @user)
+  end
+
+  def create_sessions
+    master_session = @user.master_session.create
+    onetime_session = master_session.onetime_session.new
+    onetime_session.user = @user
+    onetime_session.save
+    [master_session, onetime_session]
+  end
+
+  def get_body
+    @body = JSON.parse(response.body)
+  end
+
+  test 'reviews and responses should be shown' do
+    get "/api/v1/posts/#{@post.id}/reviews", params: {}
+    get_body
+    assert @body['body'].first['id'] == @review.id
+    assert @body['body'].first['responses'].first['id'] == @res.id
+  end
+
+  test 'should be created' do
+    m, o = create_sessions
+    text = 'awesome review'
+    post "/api/v1/posts/#{@post.id}/reviews", params: { value: { body: text }, token: { onetime: o.token } }
+    get_body
+    assert @body['status'] == 'SUCCESS'
+  end
+
+  test 'closed post should reject response' do
+    @post.close
+
+    m, o = create_sessions
+    text = 'awesome review'
+    post "/api/v1/posts/#{@post.id}/reviews", params: { value: { body: text }, token: { onetime: o.token } }
+    get_body
+    assert @body['status'] == 'FAILED'
+    assert @body['errors'].first['key'] == 'closed'
+  end
+end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -57,4 +57,11 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
     assert @body['status'] == 'FAILED'
     assert @body['errors'].first['key'] == 'closed'
   end
+
+  test 'reviews should be shown by username' do
+    get "/api/v1/users/#{@user.name}/reviews"
+    get_body
+    assert @body['status'] == 'SUCCESS'
+    assert @body['body']['total_contents_count'] == 2
+  end
 end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -36,7 +36,7 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
     get_body
     assert @body['body']['reviews'].first['id'] == @review.id
     assert @body['body']['reviews'].first['responses'].first['id'] == @res.id
-    assert @body['body']['total_contents_count'] == 1
+    assert @body['body']['total_contents_count'] == 2
   end
 
   test 'should be created' do

--- a/test/fixtures/review_coin_transactions.yml
+++ b/test/fixtures/review_coin_transactions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/review_links.yml
+++ b/test/fixtures/review_links.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/reviews.yml
+++ b/test/fixtures/reviews.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -33,18 +33,18 @@ class PostTest < ActiveSupport::TestCase
     assert @post.save
   end
 
-  test 'default state should be accepting' do
-    assert @post.state == 'accepting'
+  test 'default state should be open' do
+    assert @post.state == 'open'
   end
 
   test 'post should be resolved' do
-    @post.resolve
-    assert @post.resolved?
+    @post.close
+    assert @post.closed?
   end
 
   test 'post state should be changed' do
-    @post.change_state 'voting'
-    assert @post.state == 'voting'
+    @post.change_state 'closed'
+    assert @post.state == 'closed'
   end
 
   test 'body should be present' do

--- a/test/models/review_coin_transaction_test.rb
+++ b/test/models/review_coin_transaction_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class ReviewCoinTransactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+  include Coin
+
+  def setup
+    @user = User.create(name: 'aaa', email: 'aaa@aaa.com', password: 'aaaaaa')
+    @from = User.create(name: 'bbb', email: 'bbb@bbb.com', password: 'bbbbbb')
+    @post = @user.posts.create(title: 'title', body: 'body', code: 'code')
+    @review = Review.generate_record(body: 'body', user: @user, post: @post)
+    @review.save
+  end
+
+  test 'should be falsy' do
+    assert_not ReviewCoinTransaction.already_threw?(review_id: @review.id, user_id: @from.id)
+  end
+
+  test 'should be truthy' do
+    assert Coin.throw(amount: 100, from: @from, review: @review)
+    assert ReviewCoinTransaction.already_threw?(review_id: @review.id, user_id: @from.id)
+  end
+
+  test 'should be created' do
+    assert ReviewCoinTransaction.create_record(review: @review, from: @from, amount: 100)
+  end
+end

--- a/test/models/review_link_test.rb
+++ b/test/models/review_link_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class ReviewLinkTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+  def setup
+    @email = 'hoge@email.com'
+    @to = User.new(name: 'hoge',
+                   nickname: 'hogechan',
+                   email: @email,
+                   password: 'hogefuga')
+    @to.save
+
+    @email2 = 'hogehoge@email.com'
+    @from = User.new(name: 'fuga',
+                     nickname: 'fuga',
+                     email: @email2,
+                     password: 'hogefuga')
+    @from.save
+
+    @post = @from.posts.new
+    @post.source_url = 'http://hogehoge.com/hoge'
+    @post.body = 'この命名、きれい？'
+    @post.code = 'puts hello'
+    @post.title = 'meimei'
+    @post.bestanswer_reward = 100
+
+    @post.save
+
+    @review = Review.generate_record(body: 'hoge', user: @to, post: @post)
+    @review.save
+  end
+
+  test 'should be valid' do
+    response = @review.reply(body: 'reply', user: @from)
+    assert ReviewLink.response?(response)
+  end
+end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -33,6 +33,21 @@ class ReviewTest < ActiveSupport::TestCase
     assert @review.reply(body: 'hogehoge', user: @user)
   end
 
+  test 'empty body should not be valid' do
+    @review.body = ''
+    assert_not @review.valid?
+  end
+
+  test 'blank body should not be valid' do
+    @review.body = ' '
+    assert_not @review.valid?
+  end
+
+  test 'too long body should not be valid' do
+    @review.body = 'a' * (Review::BODY_MAX_CHARS + 1)
+    assert_not @review.valid?
+  end
+
   test 'can not reply response' do
     reply = @review.reply(body: 'hogehoge', user: @user)
     begin

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ReviewTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+  def setup
+    @email = 'hoge@email.com'
+    @user = User.new(name: 'hoge',
+                     nickname: 'hogechan',
+                     email: @email,
+                     password: 'hogefuga')
+    @user.save
+
+    @post = @user.posts.new
+    @post.source_url = 'http://hogehoge.com/hoge'
+    @post.body = 'この命名、きれい？'
+    @post.code = 'puts hello'
+    @post.title = 'meimei'
+    @post.bestanswer_reward = 100
+
+    @post.save
+
+    @review = Review.generate_record(body: 'hoge', user: @user, post: @post)
+    @review.save
+  end
+
+  test 'should be valid' do
+    assert @review.valid?
+  end
+
+  test 'should be created' do
+    assert @review.reply(body: 'hogehoge', user: @user)
+  end
+
+  test 'can not reply response' do
+    reply = @review.reply(body: 'hogehoge', user: @user)
+    begin
+      reply.reply(body: 'hogehoge', user: @user)
+    rescue
+      return assert true
+    end
+    assert false
+  end
+end

--- a/test/models/show_review_test.rb
+++ b/test/models/show_review_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'rake'
+
+class ShowReviewTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+  def setup
+    @email = 'hoge@email.com'
+    @user = User.new(name: 'hoge',
+                     nickname: 'hogechan',
+                     email: @email,
+                     password: 'hogefuga')
+    @user.save
+
+    @post = @user.posts.new
+    @post.source_url = 'http://hogehoge.com/hoge'
+    @post.body = 'この命名、きれい？'
+    @post.code = 'puts hello'
+    @post.title = 'meimei'
+    @post.bestanswer_reward = 100
+
+    @post.save
+
+    @review = Review.generate_record(body: 'hoge', user: @user, post: @post)
+    @review.save
+  end
+
+  test 'should be got' do
+    response = @review.reply(body: 'reply', user: @user)
+    reviews = ShowReview.show(@post.id)
+    review = reviews[0]
+    responses = review[:responses]
+    reply = responses[0]
+    assert reply[:body] == response.body
+  end
+end


### PR DESCRIPTION
やったこと
- レビューとそれに対するレスポンスが出来るように
- コイン機能実装の準備
- 新しく作ったPublicなメソッドにはRdocを追加した

### なぜレビューとレスポンスという概念を持ったかの今更ながらの説明
いかが現在の投稿に紐づくコメント郡の図です。
```
post:
  review1:
     response1:
     response2:
  review2:
     response1:
  review3:
```


スレッド形式でなく、なぜレビューとレスポンスに分けたかというと、レビューはコードのレビューであってほしくてレビューへのレビューであってはならないと思っていて（そのレビューへのレビューで他のレビューが流れるし）、レビューへのレビューがある場合は隔離すると見やすいかなと思ったためです。
そのためにレスポンスという概念を追加してレビューと分離しました。
しかしレビューへのレビューへのレビューまでは分離していません。（あくまで一つのレビューから派生した話題だからでもありますし、技術的な理由も少なからずあります）
