### PR TITLE
#22 ユーザーを論理削除化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rails', '~> 6.0.3', '>= 6.0.3.2'
 gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
+gem 'discard', '~> 1.2'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
       mini_mime (>= 0.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    discard (1.2.0)
+      activerecord (>= 4.2, < 7)
     ed25519 (1.2.4)
     erubi (1.9.0)
     ffi (1.13.1)
@@ -202,6 +204,7 @@ DEPENDENCIES
   capistrano-rbenv
   capistrano3-puma
   carrierwave
+  discard (~> 1.2)
   ed25519
   listen (~> 3.2)
   pg

--- a/app/controllers/api/v1/password_resets_controller.rb
+++ b/app/controllers/api/v1/password_resets_controller.rb
@@ -35,9 +35,7 @@ class Api::V1::PasswordResetsController < ApplicationController
     end
 
     user = session.user
-    user.password = user_params[:password]
-    user.create_password_digest
-    if user.save
+    if user.update_password(user_params[:password])
       session.destroy
       return render json: generate_response(SUCCESS, message: 'your password has been changed')
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -109,7 +109,7 @@ module Api
           return error_response(key: key, message: message)
         end
 
-        if selected_user.destroy
+        if selected_user.discard
           render json: generate_response(SUCCESS, message: 'user is deleted successfully')
         else
           failed_to_create selected_user

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -97,15 +97,6 @@ class Post < ApplicationRecord
     (Arel::Table.new :result)[:state].matches(post_status)
   end
 
-  # activeなPost（削除されていない）だけに絞り込みの場合は
-  # 引数にTrueを入れる
-  def self.active_post?(is_active = true)
-    if is_active
-      return (Arel::Table.new :result)[:discarded_at].eq nil
-    end
-    (Arel::Table.new :result)[:discarded_at].not_eq nil
-  end
-
   # 引数はユーザー名か空文字かnil
   def self.set_author(author)
     user = User.find_by(name: author)

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -9,6 +9,7 @@ class Review < ApplicationRecord
 
   belongs_to :post
   belongs_to :user
+  before_destroy :destroy_dependent_review_links
   has_many :review_coin_transactions, dependent: :destroy
 
   validates :body, presence: true, length: { maximum: BODY_MAX_CHARS }
@@ -60,5 +61,11 @@ class Review < ApplicationRecord
       return response
     end
     response
+  end
+
+  private
+
+  def destroy_dependent_review_links
+    ReviewLink.destroy_all_dependency(self)
   end
 end

--- a/app/models/review_link.rb
+++ b/app/models/review_link.rb
@@ -10,4 +10,19 @@ class ReviewLink < ApplicationRecord
   def self.response?(review)
     ReviewLink.exists?(to: review.id)
   end
+
+  # アソシエーションのようなもの
+  # 関連しているレコードをすべて削除する
+  # ==Argument
+  # * review :: Review
+  # ==Response
+  # * success => true
+  # * failed => Error(何が帰ってくるのかはわからない)
+  def self.destroy_all_dependency(review)
+    transaction do
+      where(from: review.id).each(&:destroy!)
+      where(to: review.id).each(&:destroy!)
+    end
+    true
+  end
 end

--- a/app/models/show_review.rb
+++ b/app/models/show_review.rb
@@ -99,8 +99,8 @@ class ShowReview < ApplicationRecord
       created_at: review_response_mix.review_created_at,
       thrown_coins: review_response_mix.review_thrown_coins,
       reviewer: {
-        name: review_response_mix.reviewer_name,
-        nickname: review_response_mix.reviewer_nickname,
+        name: review_response_mix.reviewer_name || 'deleted user',
+        nickname: review_response_mix.reviewer_nickname || 'deleted user',
         icon: icon_url(review_response_mix.reviewer_id, review_response_mix.reviewer_icon)
       }
     }
@@ -113,8 +113,8 @@ class ShowReview < ApplicationRecord
       created_at: review_response_mix.response_created_at,
       thrown_coins: review_response_mix.response_thrown_coins,
       responder: {
-        name: review_response_mix.responder_name,
-        nickname: review_response_mix.responder_nickname,
+        name: review_response_mix.responder_name || 'deleted user',
+        nickname: review_response_mix.responder_nickname || 'deleted user',
         icon: icon_url(review_response_mix.responder_id, review_response_mix.responder_icon)
       }
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
   validates :email, presence: true, length: { maximum: 255 },
             format: { with: VALID_EMAIL_REGEX },
             uniqueness: true
-  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
+  validates :password, presence: true, length: { minimum: 6 }, on: :create
   validates :explanation, presence: true, length: { maximum: 255 }, allow_nil: true
   validates :coins, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
@@ -133,6 +133,16 @@ class User < ApplicationRecord
     posts.destroy_all
     MasterSession.destroy_sessions(self)
     discard
+  end
+
+  def update_password(new_password)
+    self.password = new_password
+    if valid?(:create)
+      create_password_digest
+      save
+    else
+      false
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,8 +128,10 @@ class User < ApplicationRecord
 
   # 論理削除のコールバック
   after_discard do
-    update_random_name
-    update_random_email
+    transaction do
+      update_random_name
+      update_random_email
+    end
     posts.destroy_all
     MasterSession.destroy_sessions(self)
     discard
@@ -160,7 +162,7 @@ class User < ApplicationRecord
   def update_random_name
     1000.times do
       random_name = SecureRandom.hex(15)
-      return if update!(name: random_name)
+      return if update(name: random_name)
     end
     raise StandardError, 'failed to update user name randomly'
   end
@@ -169,7 +171,7 @@ class User < ApplicationRecord
   def update_random_email
     1000.times do
       random_name = SecureRandom.hex(15)
-      return if update!(email: "#{random_name}@4ecode.com")
+      return if update(email: "#{random_name}@4ecode.com")
     end
     raise StandardError, 'failed to update user email randomly'
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -130,7 +130,7 @@ class User < ApplicationRecord
   after_discard do
     update_random_name
     update_random_email
-    posts.discard_all
+    posts.destroy_all
     MasterSession.destroy_sessions(self)
     discard
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   has_many :asked_users, dependent: :destroy
   has_one :password_reset_session, dependent: :destroy
 
-  # deleteされていないPostのみを表示
+  # deleteされていないUserのみを表示
   default_scope { kept }
 
   mount_uploader :icon, ImageUploader

--- a/db/migrate/20200928045505_add_deleted_flag_to_user.rb
+++ b/db/migrate/20200928045505_add_deleted_flag_to_user.rb
@@ -1,0 +1,9 @@
+class AddDeletedFlagToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :discarded_at, :datetime
+    add_index :users, :discarded_at
+
+    add_column :posts, :discarded_at, :datetime
+    add_index :posts, :discarded_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -69,7 +69,8 @@ CREATE TABLE public.posts (
     code text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    user_id character varying
+    user_id character varying,
+    discarded_at timestamp without time zone
 );
 
 
@@ -120,7 +121,8 @@ CREATE TABLE public.users (
     updated_at timestamp(6) without time zone NOT NULL,
     icon character varying,
     explanation character varying,
-    coins integer
+    coins integer,
+    discarded_at timestamp without time zone
 );
 
 
@@ -589,6 +591,13 @@ CREATE INDEX index_posts_on_code ON public.posts USING btree (code);
 
 
 --
+-- Name: index_posts_on_discarded_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_discarded_at ON public.posts USING btree (discarded_at);
+
+
+--
 -- Name: index_posts_on_title; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -607,6 +616,13 @@ CREATE INDEX index_review_coin_transactions_on_review_id ON public.review_coin_t
 --
 
 CREATE INDEX index_reviews_on_post_id ON public.reviews USING btree (post_id);
+
+
+--
+-- Name: index_users_on_discarded_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_discarded_at ON public.users USING btree (discarded_at);
 
 
 --
@@ -742,6 +758,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200901113634'),
 ('20200901123706'),
 ('20200902094116'),
-('20200902133349');
+('20200902133349'),
+('20200928045505');
 
 

--- a/lib/tasks/create_view.rake
+++ b/lib/tasks/create_view.rake
@@ -4,9 +4,15 @@ namespace :db do
     ActiveRecord::Base.connection.execute <<-SQL
       create view join_reviews as
       select posts.id as post_id, review.id as review_id, review.body as review_body, review.created_at as review_created_at, review.thrown_coins as review_thrown_coins,
-      review.user_id as reviewer_id, reviewer.name as reviewer_name, reviewer.nickname as reviewer_nickname, reviewer.icon as reviewer_icon,
+      case when reviewer.discarded_at is NULL then review.user_id else NULL end as reviewer_id,
+      case when reviewer.discarded_at is NULL then reviewer.name else NULL end as reviewer_name,
+      case when reviewer.discarded_at is NULL then reviewer.nickname else NULL end as reviewer_nickname,
+      case when reviewer.discarded_at is NULL then reviewer.icon else NULL end as reviewer_icon,
       response.id as response_id, response.body as response_body, response.created_at as response_created_at, response.thrown_coins as response_thrown_coins,
-      response.user_id as responder_id, responder.name as responder_name, responder.nickname as responder_nickname, responder.icon as responder_icon
+      case when responder.discarded_at is NULL then response.user_id else NULL end as responder_id,
+      case when responder.discarded_at is NULL then responder.name else NULL end as responder_name,
+      case when responder.discarded_at is NULL then responder.nickname else NULL end as responder_nickname,
+      case when responder.discarded_at is NULL then responder.icon else NULL end as responder_icon
       from
       	posts
       left outer join

--- a/test/controllers/auth_controller_test.rb
+++ b/test/controllers/auth_controller_test.rb
@@ -17,14 +17,6 @@ class AuthControllerTest < ActionDispatch::IntegrationTest
     @user.activate
   end
 
-  def create_sessions
-    master_session = @user.master_session.create
-    onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
-    onetime_session.save
-    [master_session, onetime_session]
-  end
-
   # login test
 
   test 'user should be login' do

--- a/test/controllers/cors_test.rb
+++ b/test/controllers/cors_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class CorsTest < ActionDispatch::IntegrationTest
+  test 'cors test' do
+    get '/api/v1/users/one', headers: { origin: 'http://example.com' }
+    assert response.header['Access-Control-Allow-Origin'] == '*'
+  end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -14,14 +14,6 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     @user.activate
   end
 
-  def create_sessions
-    master_session = @user.master_session.create
-    onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
-    onetime_session.save
-    [master_session, onetime_session]
-  end
-
   # test to post
 
   test 'post should be created' do

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -189,4 +189,17 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert body['status'] == 'FAILED'
   end
+
+  # other
+  test 'deleted users post should not be found' do
+    master, onetime = create_sessions
+    user_post = @user.posts.create(title: 'test', body: 'test', code: 'code', source_url: 'test')
+    get "/api/v1/posts/#{user_post.id}", params: { token: onetime.token }
+    assert response.status == 200
+    delete "/api/v1/users/#{@user.name}", params: { token: onetime.token }
+    assert response.status == 200
+    get "/api/v1/posts/#{user_post.id}"
+  rescue ActiveRecord::RecordNotFound
+    assert true
+  end
 end

--- a/test/controllers/posts_searches_controller_test.rb
+++ b/test/controllers/posts_searches_controller_test.rb
@@ -52,4 +52,17 @@ class PostsSearchesControllerTest < ActionDispatch::IntegrationTest
 
     assert body['body']['hit_total'] == 10
   end
+
+  # other
+  test 'deleted users post should not be found' do
+    master, onetime = create_sessions
+    delete "/api/v1/users/#{@user.name}", params: { token: onetime.token }
+    assert response.status == 200
+    get '/api/v1/search/posts', params: { keyword: '_' } # '_' is wildcard
+    body = JSON.parse(response.body)
+
+    body['body']['results'].each do |result|
+      assert_not result['author']['name'] == @user.name
+    end
+  end
 end

--- a/test/controllers/posts_searches_controller_test.rb
+++ b/test/controllers/posts_searches_controller_test.rb
@@ -16,14 +16,6 @@ class PostsSearchesControllerTest < ActionDispatch::IntegrationTest
     @post = @user.posts.create(title: 'test', body: 'test', code: 'test', source_url: 'test')
   end
 
-  def create_sessions
-    master_session = @user.master_session.create
-    onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
-    onetime_session.save
-    [master_session, onetime_session]
-  end
-
   # search posts test
   test 'should be found' do
     get '/api/v1/search/posts', params: { keyword: 't' }

--- a/test/controllers/responses_controller_test.rb
+++ b/test/controllers/responses_controller_test.rb
@@ -51,4 +51,15 @@ class ResponsesControllerTest < ActionDispatch::IntegrationTest
     assert @body['status'] == 'FAILED'
     assert @body['errors'].first['key'] == 'response'
   end
+
+  test 'user should be deleted' do
+    master, onetime = create_sessions
+    text = 'awesome review'
+    post "/api/v1/posts/#{@post.id}/reviews/#{@review.id}", params: { value: { body: text }, token: { onetime: onetime.token } }
+    assert response.status == 200
+    delete "/api/v1/users/#{@user.name}", params: { token: onetime.token }
+    assert response.status == 200
+    get "/api/v1/users/#{@user.name}"
+    assert response.status == 404
+  end
 end

--- a/test/controllers/responses_controller_test.rb
+++ b/test/controllers/responses_controller_test.rb
@@ -18,14 +18,6 @@ class ResponsesControllerTest < ActionDispatch::IntegrationTest
     @review.save
   end
 
-  def create_sessions
-    master_session = @user.master_session.create
-    onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
-    onetime_session.save
-    [master_session, onetime_session]
-  end
-
   def get_body
     @body = JSON.parse(response.body)
   end

--- a/test/controllers/responses_controller_test.rb
+++ b/test/controllers/responses_controller_test.rb
@@ -16,6 +16,7 @@ class ResponsesControllerTest < ActionDispatch::IntegrationTest
     @post = @user.posts.create(title: 'test', body: 'test', code: 'test', source_url: 'test')
     @review = Review.generate_record(body: 'review', user: @user, post: @post)
     @review.save
+    @master, @onetime = create_sessions
   end
 
   def get_body
@@ -52,6 +53,7 @@ class ResponsesControllerTest < ActionDispatch::IntegrationTest
     assert @body['errors'].first['key'] == 'response'
   end
 
+  # reviewにレスポンスをしたときユーザーが消せなかったため、そのテスト
   test 'user should be deleted' do
     master, onetime = create_sessions
     text = 'awesome review'

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -19,14 +19,6 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
     @res = @review.reply(body: 'reply', user: @user)
   end
 
-  def create_sessions
-    master_session = @user.master_session.create
-    onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
-    onetime_session.save
-    [master_session, onetime_session]
-  end
-
   def get_body
     @body = JSON.parse(response.body)
   end

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -56,4 +56,12 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
     assert @body['status'] == 'SUCCESS'
     assert @body['body']['total_contents_count'] == 2
   end
+
+  test 'deleted posts review should not be found' do
+    master, onetime = create_sessions
+    delete "/api/v1/users/#{@user.name}", params: { token: onetime.token }
+    assert response.status == 200
+    get "/api/v1/users/#{@user.name}"
+    assert response.status == 404
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -23,14 +23,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     @user2.activate
   end
 
-  def create_sessions
-    master_session = @user.master_session.create
-    onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
-    onetime_session.save
-    [master_session, onetime_session]
-  end
-
   # create user test
 
   test 'invalid name should be rejected' do

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -183,4 +183,12 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     delete '/api/v1/users/hoge', params: { token: onetime.token }
     assert response.status == 200
   end
+
+  test 'deleted user should not be found' do
+    master, onetime = create_sessions
+    delete "/api/v1/users/#{@user.name}", params: { token: onetime.token }
+    assert response.status == 200
+    get "/api/v1/users/#{@user.name}"
+    assert response.status == 404
+  end
 end

--- a/test/controllers/users_searches_controller_test.rb
+++ b/test/controllers/users_searches_controller_test.rb
@@ -40,6 +40,18 @@ class UsersSearchesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'deleted user should not be found' do
+    master, onetime = create_sessions
+    delete "/api/v1/users/#{@user.name}", params: { token: onetime.token }
+    assert response.status == 200
+    get '/api/v1/search/users', params: { keyword: '_' } # '_' is wildcard
+    body = JSON.parse(response.body)
+
+    body['body']['results'].each do |result|
+      assert_not result['name'] == @user.name
+    end
+  end
+
   test 'not activated user should not be found' do
     get '/api/v1/search/users', params: { keyword: 'not' }
     body = JSON.parse(response.body)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,13 +21,11 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'password should be present (nonblank)' do
-    @user.password = ' ' * 6
-    assert_not @user.valid?
+    assert_not @user.update_password(' ' * 6)
   end
 
   test 'password should have a minimum length' do
-    @user.password = 'a' * 5
-    assert_not @user.valid?
+    assert_not @user.update_password('a' * 5)
   end
 
   test 'id should be present' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,10 @@
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+require_relative 'utils/test_utils'
 
 class ActiveSupport::TestCase
+  include TestUtils
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)
 

--- a/test/utils/test_utils.rb
+++ b/test/utils/test_utils.rb
@@ -1,8 +1,8 @@
 module TestUtils
-  def create_sessions
-    master_session = @user.master_session.create
+  def create_sessions(user = @user)
+    master_session = user.master_session.create
     onetime_session = master_session.onetime_session.new
-    onetime_session.user = @user
+    onetime_session.user = user
     onetime_session.save
     [master_session, onetime_session]
   end

--- a/test/utils/test_utils.rb
+++ b/test/utils/test_utils.rb
@@ -1,0 +1,9 @@
+module TestUtils
+  def create_sessions
+    master_session = @user.master_session.create
+    onetime_session = master_session.onetime_session.new
+    onetime_session.user = @user
+    onetime_session.save
+    [master_session, onetime_session]
+  end
+end


### PR DESCRIPTION
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#22 
基本的には上記issueのための変更ですが、変更に伴うバグが発生したため、それの対応も行っています。

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- Userの論理削除化
  - 削除したユーザーの名前・Emailの開放（同値で再登録可能）
  - 削除したユーザーの名前やEmailは30文字のランダムな文字列に置き換えられる
- testのutilの作成
  - 重複のせいで新たなテストが非常に書きづらかったため対応
- Postに紐づくレビューに紐づくレスポンスがあった場合に、完全に削除ができるように対応
  - Userの削除時に引っかかっていた部分。以前はこれができていなかったため、親であるUserが削除できない状態だった。
- corsのテストの追加
  - 度々指摘が上がるので、このブランチで対応。そもそもアクセスができないのは検証に困る可能性があるので早期発見のため、早めに行った。
  - [補足]追加時、サーバーのCORS設定に問題はないことをcurlで確認済み。
    - 使用したコマンド`curl https://api.4ecode.com/api/v1/users/ta -H "Origin: http://example.com" OPTIONS --verbose`
- 削除されたUserが他人のPostやレビューに残した返答は、deleted userとして表示
  - VIEWのSQLを変更
- Userのパスワードが空になったときのエラーが発生してテストが通らなくなったので、その対応
  - update_passwordメソッドを作成

### 流れ
1. Userを削除
2. Userのポストを完全に削除
  - それに紐づくレビューやレスポンスなどもすべて削除
3. 削除されたUserが他人のPostやレビューに残した返答は、deleted userとして表示。

## レビュー時に重点的に見てほしい点
<!-- 気になる箇所があれば明示してあるとレビューしやすい -->

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
- DELETE /api/v1/users/:name
  - 削除時のバグを取り除いた
- DELETE /api/v1/posts/:id
  - 削除時のバグを取り除いた（論理削除する際に必然的に取り除く形となった）
- GET /api/v1/users/:name/reviews
  - deleteされたユーザーのレビューは表示しない
- GET /api/v1/posts/:id/reviews
  - deleteされたユーザーのレビューはauthorがdeleted userに

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
マイグレーションをする必要があります。
VIEWを更新する必要があります。
```
$ bundle exec rails db:migrate
$ bundle exec rails db:drop_view
$ bundle exec rails db:create_view
```

## 補足
<!-- ローカル環境で試す際の注意点、など -->
特に無し。(ローカルで試す人いないと思うので)
