### PR TITLE
fix: rewrite SERVER_TYPE to environment

### DIFF
--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -6,7 +6,7 @@ set :branch, 'develop'
 set :deploy_to, "/var/www/html/fourecode-dev"
 set :bundle_gemfile, -> { release_path.join('Gemfile') }
 
-set :SERVER_TYPE, 'development'
+ENV['SERVER_TYPE'] = 'development'
 
 set :ssh_options, {
   user: "#{ENV['SERVER_USER'] || 'rails'}",

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -12,7 +12,7 @@ server '4ecode.com', user: 'rails', roles: %w[app db]
 set :rails_env, 'production'
 set :deploy_to, "/var/www/html/fourecode"
 set :bundle_gemfile, -> { release_path.join('Gemfile') }
-set :SERVER_TYPE, 'production'
+ENV['SERVER_TYPE'] = 'production'
 # role-based syntax
 # ==================
 


### PR DESCRIPTION
## 概要
環境変数の設定がうまく行っていなかったので、それの修正

## 変更内容

```
set :SERVER_TYPE, 'hogehoge'
```

この方法では環境変数が正しくセットされていなかった。

```
ENV['SERVER_TYPE'] = 'hogehoge'
```

これが正しい方法のようだ。

## レビュー時に重点的に見てほしい点
なし

## 影響範囲
なし

## 動作要件
なし

## 補足
なし
